### PR TITLE
allow unicode chars in build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m
+systemProp.file.encoding=utf-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
I was trying to build this project locally, but was encountering issues because of the use of unicode characters as variable names.
I needed to add this small change to be able to compile the project successfully. I thought it might help other people.